### PR TITLE
remove spin input

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -108,3 +108,14 @@ button:focus {
     background-color: #292a2b;
   }
 }
+
+
+/* Removendo "Spin" do input tipo number*/
+input[type='number']::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+}
+
+input[type='number'] {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}


### PR DESCRIPTION
Removi **via CSS** o "Spin" dos elementos vazio `<input  />` do tipo number, ou seja, que possui o atributo `type` com valor `number`, assim melhorando o design da aplicação removendo a possibilidade de uma possível estranheza por quebrar a paleta de cores da aplicação.